### PR TITLE
Implement Couchbase Lite query execution and formatting

### DIFF
--- a/CouchbaseLiteQueryTester/Controls/SyntaxHighlightingEditor.cs
+++ b/CouchbaseLiteQueryTester/Controls/SyntaxHighlightingEditor.cs
@@ -1,0 +1,197 @@
+using System;
+using CouchbaseLiteQueryTester.Utilities;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace CouchbaseLiteQueryTester.Controls
+{
+    public class SyntaxHighlightingEditor : Grid
+    {
+        private readonly Editor _editor;
+        private readonly Label _overlayLabel;
+        private bool _suppressTextCallback;
+        private readonly Application? _application;
+
+        public SyntaxHighlightingEditor()
+        {
+            _overlayLabel = new Label
+            {
+                LineBreakMode = LineBreakMode.CharacterWrap,
+                HorizontalTextAlignment = TextAlignment.Start,
+                VerticalTextAlignment = TextAlignment.Start,
+                TextColor = Colors.Black,
+                BackgroundColor = Colors.Transparent,
+                InputTransparent = true
+            };
+
+            _editor = new Editor
+            {
+                BackgroundColor = Colors.Transparent,
+                TextColor = Colors.Transparent,
+                PlaceholderColor = Color.FromArgb("#7F7F7F"),
+                HorizontalOptions = LayoutOptions.Fill,
+                VerticalOptions = LayoutOptions.Fill,
+                AutoSize = EditorAutoSizeOption.TextChanges
+            };
+
+            _editor.TextChanged += HandleEditorTextChanged;
+
+            Children.Add(_overlayLabel);
+            Children.Add(_editor);
+
+            SetDefaultFontValues();
+            ApplyHighlighting(string.Empty);
+
+            _application = Application.Current;
+            if (_application is not null)
+            {
+                _application.RequestedThemeChanged += HandleRequestedThemeChanged;
+            }
+        }
+
+        public event EventHandler<TextChangedEventArgs>? TextChanged;
+
+        public Editor InnerEditor => _editor;
+
+        public static readonly BindableProperty TextProperty = BindableProperty.Create(
+            nameof(Text),
+            typeof(string),
+            typeof(SyntaxHighlightingEditor),
+            string.Empty,
+            BindingMode.TwoWay,
+            propertyChanged: OnTextPropertyChanged);
+
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        private static void OnTextPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var control = (SyntaxHighlightingEditor)bindable;
+            var text = newValue as string ?? string.Empty;
+
+            if (control._editor.Text != text)
+            {
+                control._suppressTextCallback = true;
+                control._editor.Text = text;
+                control._suppressTextCallback = false;
+            }
+
+            control.ApplyHighlighting(text);
+        }
+
+        public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(
+            nameof(Placeholder),
+            typeof(string),
+            typeof(SyntaxHighlightingEditor),
+            string.Empty,
+            propertyChanged: OnPlaceholderChanged);
+
+        public string Placeholder
+        {
+            get => (string)GetValue(PlaceholderProperty);
+            set => SetValue(PlaceholderProperty, value);
+        }
+
+        private static void OnPlaceholderChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var control = (SyntaxHighlightingEditor)bindable;
+            control._editor.Placeholder = newValue as string;
+        }
+
+        public static readonly BindableProperty FontSizeProperty = BindableProperty.Create(
+            nameof(FontSize),
+            typeof(double),
+            typeof(SyntaxHighlightingEditor),
+            Device.GetNamedSize(NamedSize.Medium, typeof(Editor)),
+            propertyChanged: OnFontSizeChanged);
+
+        public double FontSize
+        {
+            get => (double)GetValue(FontSizeProperty);
+            set => SetValue(FontSizeProperty, value);
+        }
+
+        private static void OnFontSizeChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var control = (SyntaxHighlightingEditor)bindable;
+            var size = (double)newValue;
+            control._editor.FontSize = size;
+            control._overlayLabel.FontSize = size;
+        }
+
+        public static readonly BindableProperty FontFamilyProperty = BindableProperty.Create(
+            nameof(FontFamily),
+            typeof(string),
+            typeof(SyntaxHighlightingEditor),
+            default(string),
+            propertyChanged: OnFontFamilyChanged);
+
+        public string? FontFamily
+        {
+            get => (string?)GetValue(FontFamilyProperty);
+            set => SetValue(FontFamilyProperty, value);
+        }
+
+        private static void OnFontFamilyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            var control = (SyntaxHighlightingEditor)bindable;
+            var family = newValue as string;
+            control._editor.FontFamily = family;
+            control._overlayLabel.FontFamily = family;
+        }
+
+        public new bool Focus()
+        {
+            return _editor.Focus();
+        }
+
+        public new void Unfocus()
+        {
+            _editor.Unfocus();
+        }
+
+        protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+        {
+            if (args.NewHandler is null && _application is not null)
+            {
+                _application.RequestedThemeChanged -= HandleRequestedThemeChanged;
+            }
+
+            base.OnHandlerChanging(args);
+        }
+
+        private void HandleEditorTextChanged(object? sender, TextChangedEventArgs e)
+        {
+            if (_suppressTextCallback)
+            {
+                return;
+            }
+
+            ApplyHighlighting(e.NewTextValue ?? string.Empty);
+            SetValue(TextProperty, e.NewTextValue ?? string.Empty);
+            TextChanged?.Invoke(this, e);
+        }
+
+        private void ApplyHighlighting(string? text)
+        {
+            var formatted = TextHighlighter.CreateSqlFormattedString(text);
+            _overlayLabel.FormattedText = formatted;
+        }
+
+        private void HandleRequestedThemeChanged(object? sender, AppThemeChangedEventArgs e)
+        {
+            ApplyHighlighting(Text);
+        }
+
+        private void SetDefaultFontValues()
+        {
+            var defaultSize = Device.GetNamedSize(NamedSize.Medium, typeof(Editor));
+            _editor.FontSize = defaultSize;
+            _overlayLabel.FontSize = defaultSize;
+        }
+    }
+}

--- a/CouchbaseLiteQueryTester/CouchbaseLiteQueryTester.csproj
+++ b/CouchbaseLiteQueryTester/CouchbaseLiteQueryTester.csproj
@@ -59,7 +59,9 @@
 	</ItemGroup>
 
         <ItemGroup>
-                <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+	        <PackageReference Include="CommunityToolkit.Maui" Version="12.2.0" />
+			<PackageReference Include="CommunityToolkit.Maui.Core" Version="12.2.0" />
+                <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.100" />
                 <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
                 <PackageReference Include="Couchbase.Lite" Version="3.1.0" />
                 <PackageReference Include="Couchbase.Lite.Support.NetDesktop" Version="3.1.0" />

--- a/CouchbaseLiteQueryTester/CouchbaseLiteQueryTester.csproj
+++ b/CouchbaseLiteQueryTester/CouchbaseLiteQueryTester.csproj
@@ -58,10 +58,12 @@
 		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
+                <PackageReference Include="Couchbase.Lite" Version="3.1.0" />
+                <PackageReference Include="Couchbase.Lite.Support.NetDesktop" Version="3.1.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Folder Include="Resources\Images\" />

--- a/CouchbaseLiteQueryTester/MainPage.xaml
+++ b/CouchbaseLiteQueryTester/MainPage.xaml
@@ -34,7 +34,7 @@
                            FontSize="12"
                            TextColor="{AppThemeBinding Light=#202020, Dark=#F5F5F5}"
                            LineBreakMode="WordWrap"
-                           MaxWidthRequest="160" />
+                           WidthRequest="160" />
                 </VerticalStackLayout>
             </Grid>
 

--- a/CouchbaseLiteQueryTester/MainPage.xaml
+++ b/CouchbaseLiteQueryTester/MainPage.xaml
@@ -1,22 +1,71 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="CouchbaseLiteQueryTester.MainPage">
+             xmlns:controls="clr-namespace:CouchbaseLiteQueryTester.Controls"
+             x:Class="CouchbaseLiteQueryTester.MainPage"
+             Padding="16">
 
     <ScrollView>
-        <Grid RowDefinitions="*,2*">
-            <Grid Grid.Row="0" ColumnDefinitions="*, 150">
-               
-                <Editor x:Name="QueryEditor" Grid.Column="0" Placeholder="Enter SQL++ query here"/>
+        <Grid RowDefinitions="Auto,Auto" RowSpacing="16">
+            <Grid ColumnDefinitions="*,160" ColumnSpacing="16" Grid.Row="0">
+                <Border Grid.Column="0"
+                        StrokeThickness="1"
+                        Stroke="{AppThemeBinding Light=#33000000, Dark=#44FFFFFF}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFFFF, Dark=#1E1E1E}"
+                        Padding="0">
+                    <controls:SyntaxHighlightingEditor x:Name="QueryEditor"
+                                                         HeightRequest="220"
+                                                         Placeholder="Enter SQL++ query here"
+                                                         FontFamily="Courier New"
+                                                         FontSize="14" />
+                </Border>
 
-                <Button x:Name="OpenButton" Grid.Column="1" Text="Open DB" WidthRequest="150" HeightRequest="50" VerticalOptions="Start" HorizontalOptions="End" />
-                <Button x:Name="ExecuteButton" Grid.Column="1" Text="Execute" WidthRequest="150" HeightRequest="50" VerticalOptions="End" HorizontalOptions="End" />
+                <VerticalStackLayout Grid.Column="1" Spacing="12">
+                    <Button x:Name="OpenButton"
+                            Text="Open DB"
+                            HeightRequest="44"
+                            Clicked="OnOpenDatabaseClicked" />
+                    <Button x:Name="ExecuteButton"
+                            Text="Execute"
+                            HeightRequest="44"
+                            Clicked="OnExecuteQueryClicked" />
+                    <Label x:Name="DatabaseStatusLabel"
+                           Text="No database selected"
+                           FontSize="12"
+                           TextColor="{AppThemeBinding Light=#202020, Dark=#F5F5F5}"
+                           LineBreakMode="WordWrap"
+                           MaxWidthRequest="160" />
+                </VerticalStackLayout>
             </Grid>
 
-            <Grid Grid.Row="1" ColumnDefinitions="*, 150">
-                <Editor x:Name="ResultView" Grid.Column="0" IsReadOnly="True" />
-            
-                <Button x:Name="ClearButton" Grid.Column="1" Text="Clear" WidthRequest="150" HeightRequest="50" VerticalOptions="End" HorizontalOptions="End" />
+            <Grid ColumnDefinitions="*,160" ColumnSpacing="16" Grid.Row="1">
+                <Border Grid.Column="0"
+                        StrokeThickness="1"
+                        Stroke="{AppThemeBinding Light=#33000000, Dark=#44FFFFFF}"
+                        Padding="8"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFFFF, Dark=#1E1E1E}">
+                    <ScrollView x:Name="ResultScrollView" Orientation="Both">
+                        <Label x:Name="ResultLabel"
+                               FontFamily="Courier New"
+                               FontSize="14"
+                               LineBreakMode="NoWrap"
+                               HorizontalOptions="Start"
+                               VerticalOptions="Start" />
+                    </ScrollView>
+                </Border>
+
+                <VerticalStackLayout Grid.Column="1" Spacing="12">
+                    <Button x:Name="ClearButton"
+                            Text="Clear"
+                            HeightRequest="44"
+                            Clicked="OnClearResultsClicked" />
+                    <Label x:Name="ResultSummaryLabel"
+                           FontAttributes="Bold"
+                           FontSize="12"
+                           TextColor="{AppThemeBinding Light=#202020, Dark=#F5F5F5}"
+                           LineBreakMode="WordWrap"
+                           Text="Results will appear here" />
+                </VerticalStackLayout>
             </Grid>
         </Grid>
     </ScrollView>

--- a/CouchbaseLiteQueryTester/MainPage.xaml.cs
+++ b/CouchbaseLiteQueryTester/MainPage.xaml.cs
@@ -5,13 +5,9 @@ using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using CommunityToolkit.Maui.Storage;
 using Couchbase.Lite;
 using CouchbaseLiteQueryTester.Utilities;
-using Microsoft.Maui.ApplicationModel;
-using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
-using Microsoft.Maui.Storage;
-using System.Threading.Tasks;
 
 namespace CouchbaseLiteQueryTester
 {
@@ -52,17 +48,20 @@ namespace CouchbaseLiteQueryTester
 
         private async Task<string?> PickDatabaseFolderAsync()
         {
-#if WINDOWS || MACCATALYST
-            var result = await FolderPicker.Default.PickAsync(new FolderPickerOptions
-            {
-                Title = "Select a Couchbase Lite .cblite2 database"
-            });
+            var result = await FolderPicker.Default.PickAsync(new CancellationToken());
 
+//#if WINDOWS || MACCATALYST
+            /*
+                        var result = await FolderPicker.Default.PickAsync(new FolderPickerOptions
+                        {
+                            Title = "Select a Couchbase Lite .cblite2 database"
+                        });
+            */
             return result?.Folder?.Path;
-#else
-            await Task.CompletedTask;
-            throw new PlatformNotSupportedException("Selecting a database is currently supported on Windows and Mac only.");
-#endif
+//#else
+//            await Task.CompletedTask;
+//            throw new PlatformNotSupportedException("Selecting a database is currently supported on Windows and Mac only.");
+//#endif
         }
 
         private void OpenDatabase(string folderPath)
@@ -116,7 +115,7 @@ namespace CouchbaseLiteQueryTester
             try
             {
                 using var query = _database.CreateQuery(sql);
-                using var results = query.Execute();
+                var results = query.Execute();
 
                 var rows = new List<object?>();
                 foreach (var row in results)

--- a/CouchbaseLiteQueryTester/MainPage.xaml.cs
+++ b/CouchbaseLiteQueryTester/MainPage.xaml.cs
@@ -1,13 +1,231 @@
-﻿namespace CouchbaseLiteQueryTester
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Couchbase.Lite;
+using CouchbaseLiteQueryTester.Utilities;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using Microsoft.Maui.Storage;
+using System.Threading.Tasks;
+
+namespace CouchbaseLiteQueryTester
 {
     public partial class MainPage : ContentPage
     {
-        
+        private readonly JsonSerializerOptions _jsonOptions = new()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            WriteIndented = true
+        };
+
+        private Database? _database;
+
         public MainPage()
         {
             InitializeComponent();
+            ExecuteButton.IsEnabled = false;
+            ResultSummaryLabel.Text = "Results will appear here";
         }
 
-        
+        private async void OnOpenDatabaseClicked(object sender, EventArgs e)
+        {
+            try
+            {
+                var folderPath = await PickDatabaseFolderAsync();
+                if (string.IsNullOrWhiteSpace(folderPath))
+                {
+                    return;
+                }
+
+                OpenDatabase(folderPath);
+            }
+            catch (Exception ex)
+            {
+                ShowError($"Failed to open database: {ex.Message}");
+            }
+        }
+
+        private async Task<string?> PickDatabaseFolderAsync()
+        {
+#if WINDOWS || MACCATALYST
+            var result = await FolderPicker.Default.PickAsync(new FolderPickerOptions
+            {
+                Title = "Select a Couchbase Lite .cblite2 database"
+            });
+
+            return result?.Folder?.Path;
+#else
+            await Task.CompletedTask;
+            throw new PlatformNotSupportedException("Selecting a database is currently supported on Windows and Mac only.");
+#endif
+        }
+
+        private void OpenDatabase(string folderPath)
+        {
+            if (!Directory.Exists(folderPath))
+            {
+                throw new DirectoryNotFoundException("The selected folder does not exist.");
+            }
+
+            var directoryInfo = new DirectoryInfo(folderPath);
+            if (!directoryInfo.Name.EndsWith(".cblite2", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("The selected folder is not a .cblite2 Couchbase Lite database.");
+            }
+
+            var parent = directoryInfo.Parent?.FullName ?? throw new InvalidOperationException("Unable to determine the database directory.");
+            var dbName = Path.GetFileNameWithoutExtension(directoryInfo.Name);
+
+            _database?.Dispose();
+
+            var config = new DatabaseConfiguration
+            {
+                Directory = parent
+            };
+
+            _database = new Database(dbName, config);
+
+            ExecuteButton.IsEnabled = true;
+            DatabaseStatusLabel.Text = $"Connected: {dbName}{Environment.NewLine}{directoryInfo.FullName}";
+            ResultSummaryLabel.Text = "Database opened. Ready for queries.";
+            ClearResultsContent();
+        }
+
+        private void OnExecuteQueryClicked(object sender, EventArgs e)
+        {
+            ClearResultsContent();
+
+            if (_database is null)
+            {
+                ShowError("Please open a Couchbase Lite database first.");
+                return;
+            }
+
+            var sql = QueryEditor.Text?.Trim();
+            if (string.IsNullOrWhiteSpace(sql))
+            {
+                ShowError("Enter a SQL++ query to execute.");
+                return;
+            }
+
+            try
+            {
+                using var query = _database.CreateQuery(sql);
+                using var results = query.Execute();
+
+                var rows = new List<object?>();
+                foreach (var row in results)
+                {
+                    rows.Add(Simplify(row.ToDictionary()));
+                }
+
+                var json = JsonSerializer.Serialize(rows, _jsonOptions);
+                DisplayJson(json, rows.Count);
+            }
+            catch (Exception ex)
+            {
+                ShowError(ex.Message);
+            }
+        }
+
+        private void DisplayJson(string json, int rowCount)
+        {
+            var formatted = TextHighlighter.CreateJsonFormattedString(json);
+
+            ResultLabel.FormattedText = formatted;
+            ResultSummaryLabel.Text = rowCount == 1 ? "1 row returned" : $"{rowCount} rows returned";
+
+            MainThread.BeginInvokeOnMainThread(async () =>
+            {
+                await Task.Delay(50);
+                await ResultScrollView.ScrollToAsync(0, 0, false);
+            });
+        }
+
+        private void OnClearResultsClicked(object sender, EventArgs e)
+        {
+            ClearResultsContent();
+            ResultSummaryLabel.Text = "Results cleared.";
+        }
+
+        private void ShowError(string message)
+        {
+            var formatted = new FormattedString();
+            formatted.Spans.Add(new Span
+            {
+                Text = message,
+                TextColor = Colors.Red
+            });
+
+            ResultLabel.FormattedText = formatted;
+            ResultSummaryLabel.Text = "An error occurred.";
+        }
+
+        private void ClearResultsContent()
+        {
+            ResultLabel.FormattedText = new FormattedString();
+            ResultLabel.Text = string.Empty;
+        }
+
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            _database?.Dispose();
+            _database = null;
+            ExecuteButton.IsEnabled = false;
+            DatabaseStatusLabel.Text = "No database selected";
+        }
+
+        private static object? Simplify(object? value)
+        {
+            switch (value)
+            {
+                case null:
+                    return null;
+                case IDictionary<string, object?> dictionary:
+                    return dictionary.ToDictionary(kvp => kvp.Key, kvp => Simplify(kvp.Value));
+                case IReadOnlyDictionary<string, object?> readOnlyDictionary:
+                    return readOnlyDictionary.ToDictionary(kvp => kvp.Key, kvp => Simplify(kvp.Value));
+                case IEnumerable<KeyValuePair<string, object?>> pairs:
+                {
+                    var map = new Dictionary<string, object?>();
+                    foreach (var kvp in pairs)
+                    {
+                        map[kvp.Key] = Simplify(kvp.Value);
+                    }
+
+                    return map;
+                }
+                case IEnumerable enumerable when value is not string:
+                {
+                    var list = new List<object?>();
+                    foreach (var item in enumerable)
+                    {
+                        list.Add(Simplify(item));
+                    }
+
+                    return list;
+                }
+                case byte[] bytes:
+                    return Convert.ToBase64String(bytes);
+                case ReadOnlyMemory<byte> memory:
+                    return Convert.ToBase64String(memory.ToArray());
+                case Blob blob:
+                    return new Dictionary<string, object?>
+                    {
+                        ["@type"] = "blob",
+                        ["contentType"] = blob.ContentType,
+                        ["length"] = blob.Length,
+                        ["digest"] = blob.Digest
+                    };
+                default:
+                    return value;
+            }
+        }
     }
 }

--- a/CouchbaseLiteQueryTester/MauiProgram.cs
+++ b/CouchbaseLiteQueryTester/MauiProgram.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+
+#if WINDOWS || MACCATALYST
+using Couchbase.Lite.Support;
+#endif
 
 namespace CouchbaseLiteQueryTester
 {
@@ -7,6 +11,11 @@ namespace CouchbaseLiteQueryTester
         public static MauiApp CreateMauiApp()
         {
             var builder = MauiApp.CreateBuilder();
+
+#if WINDOWS || MACCATALYST
+            NetDesktop.Activate();
+#endif
+
             builder
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>
@@ -16,7 +25,7 @@ namespace CouchbaseLiteQueryTester
                 });
 
 #if DEBUG
-    		builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/CouchbaseLiteQueryTester/MauiProgram.cs
+++ b/CouchbaseLiteQueryTester/MauiProgram.cs
@@ -1,3 +1,6 @@
+using CommunityToolkit.Maui.Core;
+using Couchbase.Lite.Support;
+using CouchbaseLiteQueryTester;
 using Microsoft.Extensions.Logging;
 
 #if WINDOWS || MACCATALYST
@@ -12,18 +15,19 @@ namespace CouchbaseLiteQueryTester
         {
             var builder = MauiApp.CreateBuilder();
 
-#if WINDOWS || MACCATALYST
-            NetDesktop.Activate();
-#endif
+//#if WINDOWS || MACCATALYST
+            NetDesktop.LoadLiteCore();
+//#endif
 
             builder
                 .UseMauiApp<App>()
+                .UseMauiApp<App>().UseMauiCommunityToolkitCore()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
-
+            
 #if DEBUG
             builder.Logging.AddDebug();
 #endif

--- a/CouchbaseLiteQueryTester/Utilities/TextHighlighter.cs
+++ b/CouchbaseLiteQueryTester/Utilities/TextHighlighter.cs
@@ -1,0 +1,333 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace CouchbaseLiteQueryTester.Utilities
+{
+    public static class TextHighlighter
+    {
+        private static readonly HashSet<string> SqlKeywords = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "SELECT", "FROM", "WHERE", "GROUP", "BY", "HAVING", "ORDER", "LIMIT", "OFFSET",
+            "JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "ON", "AS", "AND", "OR", "NOT",
+            "IN", "IS", "NULL", "ARRAY", "FOR", "WHEN", "THEN", "ELSE", "END", "DISTINCT", "ANY",
+            "EVERY", "SATISFIES", "LIKE", "BETWEEN", "CASE", "LET", "USE", "KEYS", "INSERT", "UPDATE",
+            "DELETE", "UNNEST", "META", "TRUE", "FALSE", "UNION", "ALL", "EXCEPT", "INTERSECT", "UPSERT",
+            "VALUES", "RETURNING", "EXISTS", "PRIMARY", "KEY", "SET"
+        };
+
+        private readonly record struct SyntaxPalette(
+            Color Default,
+            Color Keyword,
+            Color String,
+            Color Number,
+            Color Comment,
+            Color Property,
+            Color Boolean);
+
+        public static FormattedString CreateSqlFormattedString(string? text)
+        {
+            var formatted = new FormattedString();
+            var palette = GetPalette();
+            if (string.IsNullOrEmpty(text))
+            {
+                formatted.Spans.Add(new Span { Text = string.Empty, TextColor = palette.Default });
+                return formatted;
+            }
+
+            int index = 0;
+            while (index < text.Length)
+            {
+                var span = NextSqlSpan(text, ref index, palette);
+                if (span is not null)
+                {
+                    formatted.Spans.Add(span);
+                }
+            }
+
+            return formatted;
+        }
+
+        public static FormattedString CreateJsonFormattedString(string? json)
+        {
+            var formatted = new FormattedString();
+            var palette = GetPalette();
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                formatted.Spans.Add(new Span { Text = string.Empty, TextColor = palette.Default });
+                return formatted;
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(json);
+                AppendJsonElement(formatted, document.RootElement, 0, palette);
+            }
+            catch (JsonException)
+            {
+                formatted.Spans.Add(new Span { Text = json, TextColor = palette.Default });
+            }
+
+            return formatted;
+        }
+
+        private static Span? NextSqlSpan(string text, ref int index, SyntaxPalette palette)
+        {
+            if (index >= text.Length)
+            {
+                return null;
+            }
+
+            char current = text[index];
+
+            if (char.IsWhiteSpace(current))
+            {
+                int start = index;
+                while (index < text.Length && char.IsWhiteSpace(text[index]))
+                {
+                    index++;
+                }
+
+                return CreateSpan(text[start..index], palette.Default);
+            }
+
+            if (current == '\'' || current == '"')
+            {
+                return ParseQuoted(text, ref index, current, palette);
+            }
+
+            if (current == '-' && index + 1 < text.Length && text[index + 1] == '-')
+            {
+                int start = index;
+                index += 2;
+                while (index < text.Length && text[index] != '\n')
+                {
+                    index++;
+                }
+
+                return CreateSpan(text[start..index], palette.Comment);
+            }
+
+            if (current == '/' && index + 1 < text.Length && text[index + 1] == '*')
+            {
+                int start = index;
+                index += 2;
+                while (index + 1 < text.Length && !(text[index] == '*' && text[index + 1] == '/'))
+                {
+                    index++;
+                }
+
+                index = Math.Min(text.Length, index + 2);
+                return CreateSpan(text[start..index], palette.Comment);
+            }
+
+            if (char.IsLetter(current) || current == '_')
+            {
+                int start = index;
+                index++;
+                while (index < text.Length && (char.IsLetterOrDigit(text[index]) || text[index] == '_'))
+                {
+                    index++;
+                }
+
+                var token = text[start..index];
+                if (SqlKeywords.Contains(token))
+                {
+                    return new Span
+                    {
+                        Text = token,
+                        TextColor = palette.Keyword,
+                        FontAttributes = FontAttributes.Bold
+                    };
+                }
+
+                return CreateSpan(token, palette.Default);
+            }
+
+            if ((current == '-' && index + 1 < text.Length && char.IsDigit(text[index + 1])) || char.IsDigit(current))
+            {
+                int start = index;
+                index++;
+                while (index < text.Length && (char.IsDigit(text[index]) || text[index] == '.' || text[index] == '_'))
+                {
+                    index++;
+                }
+
+                return CreateSpan(text[start..index], palette.Number);
+            }
+
+            index++;
+            return CreateSpan(current.ToString(), palette.Default);
+        }
+
+        private static Span ParseQuoted(string text, ref int index, char quote, SyntaxPalette palette)
+        {
+            int start = index;
+            index++;
+            var escaped = false;
+            while (index < text.Length)
+            {
+                var current = text[index];
+                index++;
+
+                if (escaped)
+                {
+                    escaped = false;
+                    continue;
+                }
+
+                if (current == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (current == quote)
+                {
+                    if (index < text.Length && text[index] == quote)
+                    {
+                        index++;
+                        continue;
+                    }
+
+                    break;
+                }
+            }
+
+            return CreateSpan(text[start..Math.Min(index, text.Length)], palette.String);
+        }
+
+        private static void AppendJsonElement(FormattedString formatted, JsonElement element, int indentLevel, SyntaxPalette palette)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    AppendJsonObject(formatted, element, indentLevel, palette);
+                    break;
+                case JsonValueKind.Array:
+                    AppendJsonArray(formatted, element, indentLevel, palette);
+                    break;
+                case JsonValueKind.String:
+                    formatted.Spans.Add(CreateSpan(element.GetRawText(), palette.String));
+                    break;
+                case JsonValueKind.Number:
+                    formatted.Spans.Add(CreateSpan(element.GetRawText(), palette.Number));
+                    break;
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    formatted.Spans.Add(CreateSpan(element.GetRawText(), palette.Boolean));
+                    break;
+                case JsonValueKind.Null:
+                    formatted.Spans.Add(CreateSpan("null", palette.Boolean));
+                    break;
+                default:
+                    formatted.Spans.Add(CreateSpan(element.GetRawText(), palette.Default));
+                    break;
+            }
+        }
+
+        private static void AppendJsonObject(FormattedString formatted, JsonElement element, int indentLevel, SyntaxPalette palette)
+        {
+            var properties = element.EnumerateObject().ToList();
+            if (properties.Count == 0)
+            {
+                formatted.Spans.Add(CreateSpan("{}", palette.Default));
+                return;
+            }
+
+            formatted.Spans.Add(CreateSpan("{\n", palette.Default));
+            for (int i = 0; i < properties.Count; i++)
+            {
+                var property = properties[i];
+                AppendIndent(formatted, indentLevel + 1, palette);
+                var encodedName = System.Text.Json.JsonEncodedText.Encode(property.Name).ToString();
+                formatted.Spans.Add(CreateSpan($"\"{encodedName}\"", palette.Property));
+                formatted.Spans.Add(CreateSpan(": ", palette.Default));
+                AppendJsonElement(formatted, property.Value, indentLevel + 1, palette);
+
+                if (i < properties.Count - 1)
+                {
+                    formatted.Spans.Add(CreateSpan(",\n", palette.Default));
+                }
+                else
+                {
+                    formatted.Spans.Add(CreateSpan("\n", palette.Default));
+                }
+            }
+
+            AppendIndent(formatted, indentLevel, palette);
+            formatted.Spans.Add(CreateSpan("}", palette.Default));
+        }
+
+        private static void AppendJsonArray(FormattedString formatted, JsonElement element, int indentLevel, SyntaxPalette palette)
+        {
+            var items = element.EnumerateArray().ToList();
+            if (items.Count == 0)
+            {
+                formatted.Spans.Add(CreateSpan("[]", palette.Default));
+                return;
+            }
+
+            formatted.Spans.Add(CreateSpan("[\n", palette.Default));
+            for (int i = 0; i < items.Count; i++)
+            {
+                AppendIndent(formatted, indentLevel + 1, palette);
+                AppendJsonElement(formatted, items[i], indentLevel + 1, palette);
+                if (i < items.Count - 1)
+                {
+                    formatted.Spans.Add(CreateSpan(",\n", palette.Default));
+                }
+                else
+                {
+                    formatted.Spans.Add(CreateSpan("\n", palette.Default));
+                }
+            }
+
+            AppendIndent(formatted, indentLevel, palette);
+            formatted.Spans.Add(CreateSpan("]", palette.Default));
+        }
+
+        private static void AppendIndent(FormattedString formatted, int indentLevel, SyntaxPalette palette)
+        {
+            if (indentLevel <= 0)
+            {
+                return;
+            }
+
+            formatted.Spans.Add(CreateSpan(new string(' ', indentLevel * 2), palette.Default));
+        }
+
+        private static Span CreateSpan(string text, Color color)
+        {
+            return new Span
+            {
+                Text = text,
+                TextColor = color
+            };
+        }
+
+        private static SyntaxPalette GetPalette()
+        {
+            var theme = Application.Current?.RequestedTheme ?? AppTheme.Light;
+            return theme == AppTheme.Dark
+                ? new SyntaxPalette(
+                    Color.FromArgb("#E8E8E8"),
+                    Color.FromArgb("#4FC1FF"),
+                    Color.FromArgb("#CE9178"),
+                    Color.FromArgb("#B5CEA8"),
+                    Color.FromArgb("#6A9955"),
+                    Color.FromArgb("#4EC9B0"),
+                    Color.FromArgb("#C586C0"))
+                : new SyntaxPalette(
+                    Color.FromArgb("#202020"),
+                    Color.FromArgb("#0066CC"),
+                    Color.FromArgb("#A31515"),
+                    Color.FromArgb("#098658"),
+                    Color.FromArgb("#6A9955"),
+                    Color.FromArgb("#1A4B94"),
+                    Color.FromArgb("#B000B5"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable selecting Couchbase Lite databases via a folder picker and running SQL++ queries
- display query results or errors as formatted, theme-aware JSON output
- add a reusable SQL syntax-highlighting editor control and shared text-highlighting utilities

## Testing
- Not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68c91a9595b88328a32747b62f89d73d